### PR TITLE
zope.index 6.1.0 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+upload_channels:
+  - sfe1ed40
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,8 +37,13 @@ test:
     - zope.index
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    # The tests would normally use zope.testrunner (pip install
+    # zope.testrunner; zope-testrunner --test-path=src) but we can use
+    # pytest --pyargs zope.install to get most of the tests run
+    - pytest --pyargs zope.index
 
 about:
   home: https://github.com/zopefoundation/zope.index

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
   sha256: 99f1e041771add767428b12967c54bdb2152b17df9233d1671efabdfe01f6524
 
 build:
+  # no btrees on s390x
+  skip: True  # [s390x]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,6 @@ requirements:
     - btrees >=4.4.1
     - persistent
     - python
-    - six
     - zope.interface
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ test:
     - pip check
     # The tests would normally use zope.testrunner (pip install
     # zope.testrunner; zope-testrunner --test-path=src) but we can use
-    # pytest --pyargs zope.install to get most of the tests run
+    # pytest --pyargs zope.index to get most of the tests run
     - pytest --pyargs zope.index
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "zope.index" %}
-{% set version = "5.2.1" %}
+{% set version = "6.1" %}
 
 
 package:
@@ -8,11 +8,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/zope.index-{{ version }}.tar.gz
-  sha256: 055c1949b532b618ee39c6d42f44ee85537a2fe3b1cf333e775a144b0c8b4861
+  sha256: 99f1e041771add767428b12967c54bdb2152b17df9233d1671efabdfe01f6524
 
 build:
-  number: 1
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
@@ -20,11 +20,12 @@ requirements:
   host:
     - pip
     - python
+    - setuptools
+    - wheel
   run:
     - btrees >=4.4.1
     - persistent
     - python
-    - setuptools
     - six
     - zope.interface
 
@@ -32,18 +33,29 @@ test:
   imports:
     - zope
     - zope.index
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/zopefoundation/zope.index
   summary: Indices for using with catalog like text, field, etc.
+  description: |
+    The zope.index package provides several indices for the Zope
+    catalog. These include:
+
+    - a field index (for indexing orderable values),
+    - a keyword index,
+    - a topic index,
+    - a text index (with support for lexicon, splitter, normalizer, etc.)
   license: ZPL-2.1
   license_file:
     - COPYRIGHT.txt
     - LICENSE.txt
+  license_family: OTHER
+  doc_url: https://zopeindex.readthedocs.io
+  dev_url: https://github.com/zopefoundation/zope.index
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
zope.index 6.1.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4972]
- dev_url:        https://github.com/zopefoundation/zope.index/tree/6.1
- conda_forge:    https://github.com/conda-forge/zope.index-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/zope.index/6.1.0
- pypi inspector: https://inspector.pypi.io/project/zope.index/6.1.0

### Explanation of changes:

- basic build
  - skip `s390x`: no `btrees`
- add upstream tests


[PKG-4972]: https://anaconda.atlassian.net/browse/PKG-4972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ